### PR TITLE
permit HUnit dependency in version 1.6

### DIFF
--- a/hcoord.cabal
+++ b/hcoord.cabal
@@ -44,7 +44,7 @@ test-suite hcoord-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
-                     , HUnit >= 1.2 && < 1.6
+                     , HUnit >= 1.2 && < 1.7
                      , hcoord
                      , mtl
                      , ieee754


### PR DESCRIPTION
This fixes the build for Nixpkgs nixos-unstable.

Also could you release a new version and publish it to Hackage?